### PR TITLE
Add sequential flow runtime engine and basic nodes

### DIFF
--- a/core/nodes/__init__.py
+++ b/core/nodes/__init__.py
@@ -1,0 +1,11 @@
+from .input import node_input
+from .output import node_output
+from .llm_chat import node_llm_chat
+
+NODE_HANDLERS = {
+    "input": node_input,
+    "output": node_output,
+    "llm.chat": node_llm_chat,
+}
+
+__all__ = ["node_input", "node_output", "node_llm_chat", "NODE_HANDLERS"]

--- a/core/nodes/input.py
+++ b/core/nodes/input.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from core.runtime.contracts import NodeContext
+
+
+async def node_input(ctx: NodeContext):
+    """Return the initial payload provided to the flow.
+
+    For the prototype the input node simply forwards its inputs
+    unchanged so downstream nodes receive the provided payload.
+    """
+
+    return ctx.inputs

--- a/core/nodes/output.py
+++ b/core/nodes/output.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from core.runtime.contracts import NodeContext
+
+
+async def node_output(ctx: NodeContext):
+    """Passthrough final payload to the caller."""
+
+    return ctx.inputs

--- a/core/runtime/engine.py
+++ b/core/runtime/engine.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any, Callable, Dict, Optional
+
+from .contracts import NodeContext, NodeHandler
+
+
+async def run_flow(
+    flow: Dict[str, Any],
+    inputs: Any,
+    handlers: Dict[str, NodeHandler],
+    emit: Optional[Callable[[Dict[str, Any]], None]] = None,
+    *,
+    run_id: Optional[str] = None,
+    user: Optional[Dict[str, Any]] = None,
+    secrets: Optional[Dict[str, str]] = None,
+    logger: Optional[Callable[[str], None]] = None,
+    timeout_ms: int = 30_000,
+) -> Any:
+    """Execute a flow sequentially.
+
+    Parameters
+    ----------
+    flow: dict
+        Flow specification containing ``nodes`` and ``edges`` arrays.
+    inputs: any
+        Initial payload supplied to the first node.
+    handlers: dict
+        Mapping of node ``type`` to async handler callable.
+    emit: callable, optional
+        Function used to emit step events. Defaults to no-op.
+    run_id: str, optional
+        Identifier for this run. Generated if not provided.
+    user: dict, optional
+        User information passed to each node context.
+    secrets: dict, optional
+        Secrets available to node handlers.
+    logger: callable, optional
+        Logger used for debugging.
+    timeout_ms: int, optional
+        Maximum time allotted for each node.
+    """
+
+    run_id = run_id or uuid.uuid4().hex
+    emit = emit or (lambda evt: None)
+    logger = logger or (lambda msg: None)
+    user = user or {}
+    secrets = secrets or {}
+
+    nodes = {n["id"]: n for n in flow.get("nodes", [])}
+    edges = {e["from"]: e["to"] for e in flow.get("edges", [])}
+
+    current_id = flow["nodes"][0]["id"] if flow.get("nodes") else None
+    payload = inputs
+
+    while current_id:
+        node = nodes[current_id]
+        handler = handlers.get(node["type"])
+        if handler is None:
+            raise KeyError(f"No handler for node type {node['type']}")
+
+        ctx = NodeContext(
+            run_id=run_id,
+            node_id=current_id,
+            inputs=payload,
+            params=node.get("params", {}),
+            secrets=secrets,
+            user=user,
+            logger=lambda m, nid=current_id: logger(f"[{nid}] {m}"),
+            emit=emit,
+            timeout_ms=timeout_ms,
+        )
+
+        emit({"type": "step_started", "node_id": current_id})
+        start = time.perf_counter()
+        try:
+            payload = await handler(ctx)
+        except Exception as exc:  # pragma: no cover - failure path
+            latency = int((time.perf_counter() - start) * 1000)
+            emit(
+                {
+                    "type": "step_failed",
+                    "node_id": current_id,
+                    "latency_ms": latency,
+                    "error": str(exc),
+                }
+            )
+            raise
+        latency = int((time.perf_counter() - start) * 1000)
+        emit({"type": "step_succeeded", "node_id": current_id, "latency_ms": latency})
+
+        current_id = edges.get(current_id)
+
+    return payload

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for imports during tests
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_runtime_engine.py
+++ b/tests/test_runtime_engine.py
@@ -1,0 +1,54 @@
+import asyncio
+
+from core.nodes.input import node_input
+from core.nodes.output import node_output
+from core.runtime.engine import run_flow
+from core.runtime.contracts import NodeContext
+
+
+async def node_add(ctx: NodeContext):
+    """Simple node that increments numeric input by a constant."""
+
+    return ctx.inputs + ctx.params.get("value", 1)
+
+
+def test_run_flow_sequential():
+    flow = {
+        "name": "demo",
+        "nodes": [
+            {"id": "n1", "type": "input", "params": {}},
+            {"id": "n2", "type": "add", "params": {"value": 1}},
+            {"id": "n3", "type": "output", "params": {}},
+        ],
+        "edges": [
+            {"from": "n1", "to": "n2"},
+            {"from": "n2", "to": "n3"},
+        ],
+    }
+
+    events = []
+    handlers = {
+        "input": node_input,
+        "add": node_add,
+        "output": node_output,
+    }
+
+    result = asyncio.run(run_flow(flow, 0, handlers, emit=lambda e: events.append(e)))
+
+    assert result == 1
+    assert [e["node_id"] for e in events] == [
+        "n1",
+        "n1",
+        "n2",
+        "n2",
+        "n3",
+        "n3",
+    ]
+    assert [e["type"] for e in events] == [
+        "step_started",
+        "step_succeeded",
+        "step_started",
+        "step_succeeded",
+        "step_started",
+        "step_succeeded",
+    ]


### PR DESCRIPTION
## Summary
- implement async flow engine that executes nodes sequentially and emits step events
- provide basic input and output node handlers with default handler registry
- add runtime tests verifying sequential execution and event emission

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898766fdc48832fa7bb3240d78b4953