### PR TITLE
Add rag retrieval node with in-memory vector store

### DIFF
--- a/core/nodes/__init__.py
+++ b/core/nodes/__init__.py
@@ -1,11 +1,27 @@
+"""Collection of built-in node handlers for the prototype runtime.
+
+This module exposes a mapping between node ``type`` strings used in a
+``FlowSpec`` and the coroutine implementing the node's behaviour.  Tests use
+``NODE_HANDLERS`` to execute small flows end‑to‑end, so any new node handler
+should be added here.
+"""
+
 from .input import node_input
 from .output import node_output
 from .llm_chat import node_llm_chat
+from .rag_retrieve import node_rag_retrieve
 
 NODE_HANDLERS = {
     "input": node_input,
     "output": node_output,
     "llm.chat": node_llm_chat,
+    "rag.retrieve": node_rag_retrieve,
 }
 
-__all__ = ["node_input", "node_output", "node_llm_chat", "NODE_HANDLERS"]
+__all__ = [
+    "node_input",
+    "node_output",
+    "node_llm_chat",
+    "node_rag_retrieve",
+    "NODE_HANDLERS",
+]

--- a/core/nodes/rag_retrieve.py
+++ b/core/nodes/rag_retrieve.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from core.runtime.contracts import NodeContext
+from core import vector_store
+
+
+async def node_rag_retrieve(ctx: NodeContext):
+    """Retrieve relevant chunks from the in-memory vector store.
+
+    The implementation is intentionally lightweight: it delegates embedding and
+    vector search to :mod:`core.vector_store`, allowing the tests to monkeypatch
+    those functions or use the provided in-memory implementation.  The node
+    returns the retrieved chunks together with a list of citation dictionaries
+    as described in the prototype specification.
+    """
+
+    query_text = (
+        ctx.inputs.get("message") if isinstance(ctx.inputs, dict) else str(ctx.inputs)
+    )
+    embedding = await vector_store.embed(query_text)
+    chunks = await vector_store.query(
+        embedding, top_k=ctx.params["top_k"], filters=ctx.params.get("filters", {})
+    )
+    ctx.logger(f"retrieved {len(chunks)} chunks")
+    citations = [
+        {"source": c.get("meta", {}).get("source"), "page": c.get("meta", {}).get("page")}
+        for c in chunks
+    ]
+    return {"chunks": chunks, "citations": citations}
+

--- a/core/vector_store.py
+++ b/core/vector_store.py
@@ -1,0 +1,90 @@
+"""Simple in-memory vector store used for tests.
+
+The real project integrates with Vertex AI Vector Search.  For the prototype and
+unit tests we provide a very small in-memory approximation with a compatible
+interface.  It supports three asynchronous functions:
+
+``create_index_if_not_exists``
+    No-op placeholder that mirrors the real API.
+``upsert``
+    Store a list of chunks in memory.  Each chunk should contain ``text`` and
+    optional ``metadata``.  Embeddings are computed automatically using the
+    ``embed`` helper.
+``query``
+    Return the ``top_k`` chunks closest to the provided embedding using a
+    euclidean distance metric.  The result format matches the structure expected
+    by the runtime's ``rag.retrieve`` node.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, List
+
+# ---------------------------------------------------------------------------
+# In-memory database
+# ---------------------------------------------------------------------------
+
+VECTOR_DB: List[Dict[str, Any]] = []
+
+
+async def create_index_if_not_exists(index_name: str) -> None:
+    """Placeholder to mirror the real vector store API."""
+
+    # The in-memory implementation always exists; nothing to do.
+    return None
+
+
+async def embed(text: str) -> List[float]:
+    """Return a trivial embedding for ``text``.
+
+    The function maps the text to a single floating point number derived from
+    the ordinal values of its characters.  While obviously not semantically
+    meaningful, it is deterministic which suffices for unit tests.
+    """
+
+    if not text:
+        return [0.0]
+    return [sum(ord(ch) for ch in text) / len(text)]
+
+
+async def upsert(chunks: List[Dict[str, Any]]) -> str:
+    """Insert ``chunks`` into the in-memory database.
+
+    Each chunk is expected to contain ``text`` and optional ``metadata``.  A
+    simple embedding is generated automatically if not supplied.  The function
+    returns a dummy task identifier similar to the asynchronous behaviour of the
+    real Vertex service.
+    """
+
+    for chunk in chunks:
+        if "embedding" not in chunk:
+            chunk["embedding"] = await embed(chunk.get("text", ""))
+        VECTOR_DB.append(chunk)
+    return f"task_{len(VECTOR_DB)}"
+
+
+async def query(
+    embedding: List[float],
+    top_k: int,
+    filters: Dict[str, Any] | None = None,
+) -> List[Dict[str, Any]]:
+    """Return the ``top_k`` most similar chunks to ``embedding``.
+
+    ``filters`` are ignored in this simplified implementation but kept for API
+    compatibility.  Results are returned in a format suitable for the
+    ``rag.retrieve`` node: a list of dicts containing ``text``, ``meta`` and
+    ``score`` fields.
+    """
+
+    def score(chunk: Dict[str, Any]) -> float:
+        emb = chunk.get("embedding", [0.0])
+        dist = math.sqrt(sum((a - b) ** 2 for a, b in zip(embedding, emb)))
+        return 1.0 / (1.0 + dist)
+
+    # Ignore filters for the prototype; a real implementation would apply them.
+    ordered = sorted(VECTOR_DB, key=score, reverse=True)[:top_k]
+    return [
+        {"text": c.get("text", ""), "meta": c.get("metadata", {}), "score": score(c)}
+        for c in ordered
+    ]

--- a/tests/test_rag_retrieve.py
+++ b/tests/test_rag_retrieve.py
@@ -1,0 +1,44 @@
+import asyncio
+
+from core.nodes.rag_retrieve import node_rag_retrieve
+from core.runtime.contracts import NodeContext
+from core import vector_store
+
+
+def setup_function():
+    vector_store.VECTOR_DB.clear()
+    asyncio.run(
+        vector_store.upsert(
+            [
+                {
+                    "id": "c1",
+                    "text": "hello world",
+                    "metadata": {"source": "doc1", "page": 1},
+                },
+                {
+                    "id": "c2",
+                    "text": "other text",
+                    "metadata": {"source": "doc2", "page": 2},
+                },
+            ]
+        )
+    )
+
+
+def test_node_rag_retrieve_basic():
+    ctx = NodeContext(
+        run_id="r1",
+        node_id="n2",
+        inputs={"message": "hello world"},
+        params={"top_k": 1},
+        secrets={},
+        user={},
+        logger=lambda msg: None,
+        emit=lambda evt: None,
+        timeout_ms=1000,
+    )
+    result = asyncio.run(node_rag_retrieve(ctx))
+    assert "chunks" in result
+    assert len(result["chunks"]) == 1
+    assert result["chunks"][0]["text"] == "hello world"
+    assert result["citations"] == [{"source": "doc1", "page": 1}]


### PR DESCRIPTION
## Summary
- implement in-memory vector store with embed, upsert, query helpers
- add rag.retrieve node handler and expose it in node registry
- include tests for rag retrieval

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689879c1e000832f9beef804eb7c313d